### PR TITLE
Fix inference_rgbdn_sft.py loading error

### DIFF
--- a/inference/inference_rgbdn_sft.py
+++ b/inference/inference_rgbdn_sft.py
@@ -58,7 +58,7 @@ def validate(
     )
     print("Loading custom transformer checkpoint...")
     if os.path.exists(weights_path):
-        subfolder = "transformer"
+        subfolder = None
     else:
         subfolder = weights_path.split("/")[-1]
         weights_path = "/".join(weights_path.split("/")[:-1])


### PR DESCRIPTION
### Description
Running the example command from the README causes an error:
```
python inference/inference_rgbdn_sft.py \
  --weights_path "anyeZHY/tesseract/tesseract_v01e_rgbdn_sft" \
  --image_path asset/images/fruit_vangogh.png \
  --prompt "pick up the apple google robot"
```
Error message:
`RuntimeError: anyeZHY/tesseract/tesseract_v01e_rgbdn_sft/transformer/config.json does not exist
`

This happens because the model downloaded from HuggingFace has all weights and config files directly under the root directory (e.g., `tesseract_v01e_rgbdn_sft/`) without any `transformer/` subfolder.

To fix this, just simply setting `subfolder=None` in from_pretrained_modify(...) to match the actual directory layout of the model.

